### PR TITLE
fix(release): resolve date handling issue in release notes 🐛

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 'lts/*'
+          node-version: '20.11.0'
+          cache: 'npm'
           
       - name: Install dependencies
         run: npm ci || npm install

--- a/package.json
+++ b/package.json
@@ -41,7 +41,11 @@
           "commitGroupsSort": "title",
           "commitsSort": ["scope", "subject"],
           "noteGroupsSort": "title",
-          "commitPartial": "* {{#if scope}}**{{scope}}:** {{/if}}{{subject}} ([{{shortHash}}]({{@root.host}}/{{@root.owner}}/{{@root.repository}}/commit/{{hash}}))\n{{#if body}}\n  {{body}}\n{{/if}}\n{{#if footer}}\n  {{footer}}\n{{/if}}"
+          "commitPartial": "* {{#if scope}}**{{scope}}:** {{/if}}{{subject}} ([{{shortHash}}]({{@root.host}}/{{@root.owner}}/{{@root.repository}}/commit/{{hash}}))\n{{#if body}}\n  {{body}}\n{{/if}}\n{{#if footer}}\n  {{footer}}\n{{/if}}",
+          "transform": {
+            "hash": "shortHash",
+            "committerDate": false
+          }
         },
         "presetConfig": {
           "types": [


### PR DESCRIPTION
Fixed release notes generation issues:

- Disabled committer date in release notes to avoid date parsing errors

- Simplified commit transformation configuration

- Set specific Node.js version (20.11.0) for better compatibility

- Added npm cache for faster CI runs