### PR TITLE
fix(ci): handle missing package-lock.json 🔧

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,10 +19,14 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20.11.0'
-          cache: 'npm'
           
-      - name: Install dependencies
-        run: npm ci || npm install
+      - name: Install dependencies and generate lock file
+        run: |
+          npm install
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+          git add package-lock.json
+          git commit -m "chore: add package-lock.json [skip ci]" || true
           
       - name: Semantic Release
         uses: cycjimmy/semantic-release-action@v4


### PR DESCRIPTION
Updated release workflow to handle missing lock file:

- Generate package-lock.json during CI

- Configure git user for lock file commit

- Temporarily disable npm cache until lock file exists

- Add fallback for when lock file already exists